### PR TITLE
feat: pickle and unpickle Environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /lake-packages/*
 /lakefile.olean
+/test/*.olean

--- a/REPL/JSON.lean
+++ b/REPL/JSON.lean
@@ -82,8 +82,8 @@ A response to a Lean command.
 -/
 structure CommandResponse where
   env : Nat
-  messages : List Message
-  sorries : List Sorry
+  messages : List Message := []
+  sorries : List Sorry := []
 deriving ToJson, FromJson
 
 /--
@@ -98,6 +98,15 @@ deriving ToJson, FromJson
 /-- Json wrapper for an error. -/
 structure Error where
   message : String
+deriving ToJson, FromJson
+
+structure PickleEnvironment where
+  env : Nat
+  pickleTo : System.FilePath
+deriving ToJson, FromJson
+
+structure UnpickleEnvironment where
+  unpickleFrom : System.FilePath
 deriving ToJson, FromJson
 
 end REPL

--- a/REPL/Lean/Environment.lean
+++ b/REPL/Lean/Environment.lean
@@ -1,0 +1,30 @@
+import REPL.Util.Pickle
+
+open System (FilePath)
+
+namespace Lean.Environment
+
+/--
+Pickle an `Environment` to disk.
+
+We only store:
+* the list of imports
+* the new constants from `Environment.constants`
+and when unpickling, we build a fresh `Environment` from the imports,
+and then add the new constants.
+-/
+def pickle (env : Environment) (path : FilePath) : IO Unit :=
+  _root_.pickle path (env.header.imports, env.constants.map₂)
+
+/--
+Unpickle an `Environment` from disk.
+
+We construct a fresh `Environment` with the relevant imports,
+and then replace the new constants.
+-/
+def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+  let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+  let env ← importModules imports {} 0
+  return ({ env with constants := { env.constants with map₂ }}, region)
+
+end Lean.Environment

--- a/REPL/Util/Pickle.lean
+++ b/REPL/Util/Pickle.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import REPL.Util.TermUnsafe
+
+/-!
+# Pickling and unpickling objects
+
+By abusing `saveModuleData` and `readModuleData` we can pickle and unpickle objects to disk.
+-/
+
+open Lean System
+
+/--
+Save an object to disk.
+If you need to write multiple objects from within a single declaration,
+you will need to provide a unique `key` for each.
+-/
+def pickle {α : Type} (path : FilePath) (x : α) (key : Name := by exact decl_name%) : IO Unit :=
+  saveModuleData path key (unsafe unsafeCast x)
+
+/--
+Load an object from disk.
+Note: The returned `CompactedRegion` can be used to free the memory behind the value
+of type `α`, using `CompactedRegion.free` (which is only safe once all references to the `α` are
+released). Ignoring the `CompactedRegion` results in the data being leaked.
+Use `withUnpickle` to call `CompactedRegion.free` automatically.
+
+This function is unsafe because the data being loaded may not actually have type `α`, and this
+may cause crashes or other bad behavior.
+-/
+unsafe def unpickle (α : Type) (path : FilePath) : IO (α × CompactedRegion) := do
+  let (x, region) ← readModuleData path
+  pure (unsafeCast x, region)
+
+/-- Load an object from disk and run some continuation on it, freeing memory afterwards. -/
+unsafe def withUnpickle [Monad m] [MonadLiftT IO m] {α β : Type}
+    (path : FilePath) (f : α → m β) : m β := do
+  let (x, region) ← unpickle α path
+  let r ← f x
+  region.free
+  pure r

--- a/test.sh
+++ b/test.sh
@@ -34,3 +34,5 @@ for infile in $IN_DIR/*.in; do
     # Remove the temporary file
     rm "$tmpfile"
 done
+
+rm -f test/*.olean

--- a/test.sh
+++ b/test.sh
@@ -34,5 +34,3 @@ for infile in $IN_DIR/*.in; do
     # Remove the temporary file
     rm "$tmpfile"
 done
-
-rm -f test/*.olean

--- a/test/pickle_environment.expected.out
+++ b/test/pickle_environment.expected.out
@@ -1,0 +1,4 @@
+{"sorries": [], "messages": [], "env": 0}
+{"sorries": [], "messages": [], "env": 0}
+{"sorries": [], "messages": [], "env": 1}
+{"sorries": [], "messages": [], "env": 2}

--- a/test/pickle_environment.in
+++ b/test/pickle_environment.in
@@ -1,0 +1,7 @@
+{"cmd": "def f := 42"}
+
+{"env": 0, "pickleTo": "test/a.olean"}
+
+{"unpickleFrom": "test/a.olean"}
+
+{"cmd": "example : f = 42 := by rfl", "env": 1}

--- a/test/pickle_environment.in
+++ b/test/pickle_environment.in
@@ -1,6 +1,6 @@
 {"cmd": "def f := 42"}
 
-{"env": 0, "pickleTo": "test/a.olean"}
+{"pickleTo": "test/a.olean", "env": 0}
 
 {"unpickleFrom": "test/a.olean"}
 

--- a/test/pickle_environment_with_imports.expected.out
+++ b/test/pickle_environment_with_imports.expected.out
@@ -1,0 +1,5 @@
+{"sorries": [], "messages": [], "env": 0}
+{"sorries": [], "messages": [], "env": 1}
+{"sorries": [], "messages": [], "env": 1}
+{"sorries": [], "messages": [], "env": 2}
+{"sorries": [], "messages": [], "env": 3}

--- a/test/pickle_environment_with_imports.in
+++ b/test/pickle_environment_with_imports.in
@@ -1,0 +1,9 @@
+{"cmd": "import Lean"}
+
+{"cmd": "def f := 42", "env": 0}
+
+{"pickleTo": "test/b.olean", "env": 1}
+
+{"unpickleFrom": "test/b.olean"}
+
+{"cmd": "example : f = 42 := by rfl", "env": 2}


### PR DESCRIPTION
As a test, I pickled the result of
```
import Mathlib

def f := 42
```
and produced a 5kb olean file. (This is good: we're not accidentally storing content from the imports.)