### PR TITLE
avoid buffering stdout to ensure immediate replies

### DIFF
--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -302,6 +302,12 @@ def parse (query : String) : IO Input := do
     | .error e => throw <| IO.userError <| toString <| toJson <|
         (⟨"Could not parse as a valid JSON command:\n" ++ e⟩ : Error)
 
+/-- Avoid buffering the output. -/
+def printFlush [ToString α] (s : α) : IO Unit := do
+  let out ← IO.getStdout
+  out.putStr (toString s)
+  out.flush -- Flush the output
+
 /-- Read-eval-print loop for Lean. -/
 unsafe def repl : IO Unit :=
   StateT.run' loop {}
@@ -318,7 +324,7 @@ where loop : M IO Unit := do
   | .unpickleEnvironment r => return toJson (← unpickleCommandSnapshot r)
   | .pickleProofSnapshot r => return toJson (← pickleProofSnapshot r)
   | .unpickleProofSnapshot r => return toJson (← unpickleProofSnapshot r)
-  IO.println "" -- easier to parse the output if there are blank lines
+  printFlush "\n" -- easier to parse the output if there are blank lines
   loop
 
 /-- Main executable function, run as `lake exe repl`. -/


### PR DESCRIPTION
NOTE: **The code is by MrProof** from here:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean4_jupyter.3A.20A.20Lean.204.20Jupyter.20kernel.20via.20repl/near/444053505

This does not change total input/output behaviour, so I did not (know how to) add any relevant tests.

See here for an example using a file and `tail -f` to see the difference this makes in *when* parts of the output are given:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean4_jupyter.3A.20A.20Lean.204.20Jupyter.20kernel.20via.20repl/near/451150175
