### PR TITLE
ignore locale to ensure test `bla` runs before `bla2`

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,9 @@ EXPECTED_DIR="test"
 
 lake build
 
+# ignore locale to ensure test `bla` runs before `bla2`
+export LC_COLLATE=C
+
 # Iterate over each .in file in the test directory
 for infile in $IN_DIR/*.in; do
     # Extract the base filename without the extension


### PR DESCRIPTION
As discussed [here on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean4_jupyter.3A.20A.20Lean.204.20Jupyter.20kernel.20via.20repl/near/454251327) the order in which bash expands `*` to go through all tests [depends on the locale](https://unix.stackexchange.com/questions/368318/does-the-bash-star-wildcard-always-produce-an-ascending-sorted-list). The change here fixes this using `LC_COLLATE=C`.