### PR TITLE
Feature: Increase Input Length

### DIFF
--- a/REPL/JSON.lean
+++ b/REPL/JSON.lean
@@ -28,8 +28,9 @@ structure Command extends CommandOptions where
   cmd : String
 deriving ToJson, FromJson
 
-/-- Process a Lean file in a fresh environment. -/
+/-- Process a Lean file in a fresh environment if `env` is not provided. -/
 structure File extends CommandOptions where
+  env: Option Nat
   path : System.FilePath
 deriving FromJson
 

--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -236,7 +236,7 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
 def processFile (s : File) : M IO (CommandResponse ⊕ Error) := do
   try
     let cmd ← IO.FS.readFile s.path
-    runCommand { s with env := none, cmd }
+    runCommand { s with env := s.env, cmd }
   catch e =>
     pure <| .inr ⟨e.toString⟩
 
@@ -264,7 +264,7 @@ partial def getLines : IO String := do
   if line.trim.isEmpty then
     return line
   else
-    return line ++ (← getLines)
+    return line.trimRight ++ (← getLines)
 
 instance [ToJson α] [ToJson β] : ToJson (α ⊕ β) where
   toJson x := match x with

--- a/test/Mathlib/test/file_with_env.expected.out
+++ b/test/Mathlib/test/file_with_env.expected.out
@@ -1,0 +1,24 @@
+{"env": 0}
+
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 9, "column": 4},
+   "goal": "x y : ℝ\n⊢ ∀ (a b : ℚ), a * b = b * a",
+   "endPos": {"line": 9, "column": 9}}],
+ "messages":
+ [{"severity": "error",
+   "pos": {"line": 13, "column": 39},
+   "endPos": {"line": 13, "column": 44},
+   "data":
+   "type mismatch\n  seq_x\nhas type\n  ℕ → ℚ : Type\nbut is expected to have type\n  Prop : Type"},
+  {"severity": "error",
+   "pos": {"line": 1, "column": 59},
+   "endPos": {"line": 13, "column": 44},
+   "data":
+   "unsolved goals\ncase h_approx_x\nx y : ℝ\nh_rational : ∀ (a b : ℚ), a * b = b * a\n⊢ ∃ seq_x, sorry\n\nx y : ℝ\nh_rational : ∀ (a b : ℚ), a * b = b * a\nh_approx_x : ∃ seq_x, sorry\n⊢ x * y = y * x"},
+  {"severity": "error",
+   "pos": {"line": 13, "column": 45},
+   "endPos": null,
+   "data": "expected token"}],
+ "env": 1}
+

--- a/test/Mathlib/test/file_with_env.in
+++ b/test/Mathlib/test/file_with_env.in
@@ -1,0 +1,3 @@
+{"cmd": "import Mathlib\nopen Real"}
+
+{"path": "test/file_with_env.lean", "env": 0}

--- a/test/Mathlib/test/file_with_env.lean
+++ b/test/Mathlib/test/file_with_env.lean
@@ -1,0 +1,28 @@
+theorem mul_comm_real_sketch : ∀ x y : ℝ, x * y = y * x := by
+  -- Consider any two real numbers x and y
+  intros x y
+
+  -- Strategy: First prove for rationals, then extend to reals using density
+
+  -- 1. Prove the property holds for rational numbers
+  have h_rational : ∀ (a b : ℚ), (a * b = b * a) := by
+    sorry
+
+  -- 2. Approximate real numbers with rational sequences
+  -- For any real number, there exists a convergent sequence of rationals
+  have h_approx_x : ∃ (seq_x : ℕ → ℚ), seq_x ⟀ x := by
+    sorry
+  have h_approx_y : ∃ (seq_y : ℕ → ℚ), seq_y ⟀ y := by
+    sorry
+
+  -- 3. Use properties of limits
+  -- If sequences satisfy commutativity, their limits also satisfy it
+  have h_limit_preserves : ∀ (seq_x seq_y : ℕ → ℚ),
+    (seq_x ⟀ x) → (seq_y ⟀ y) →
+    (seq_x n * seq_y n = seq_y n * seq_x n) →
+    (x * y = y * x) := by
+    sorry
+
+  -- 4. Combine all results
+  -- Use continuity and limit properties to complete the proof
+  sorry

--- a/test/sketch_theorem.expected.out
+++ b/test/sketch_theorem.expected.out
@@ -1,0 +1,57 @@
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 2, "column": 0},
+   "goal": "⊢ 1 = 1",
+   "endPos": {"line": 2, "column": 5}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 11},
+   "data": "declaration uses 'sorry'"}],
+ "env": 0}
+
+{"sorries":
+ [{"proofState": 1,
+   "pos": {"line": 11, "column": 5},
+   "goal":
+   "case zero\nm : Nat\nh_base : 0 + m = m\nh_symm : m + 0 = m\n⊢ 0 + m = m + 0",
+   "endPos": {"line": 11, "column": 10}},
+  {"proofState": 2,
+   "pos": {"line": 24, "column": 5},
+   "goal":
+   "case succ\nm n : Nat\nih h_inductive : n + m = m + n\nh_pull_succ_out_from_right : m + n.succ = (m + n).succ\nh_flip_n_plus_m : (n + m).succ = (m + n).succ\nh_pull_succ_out_from_left : n.succ + m = (n + m).succ\n⊢ n + 1 + m = m + (n + 1)",
+   "endPos": {"line": 24, "column": 10}},
+  {"proofState": 3,
+   "pos": {"line": 7, "column": 31},
+   "goal": "m : Nat\n⊢ 0 + m = m",
+   "endPos": {"line": 7, "column": 36}},
+  {"proofState": 4,
+   "pos": {"line": 9, "column": 31},
+   "goal": "m : Nat\nh_base : 0 + m = m\n⊢ m + 0 = m",
+   "endPos": {"line": 9, "column": 36}},
+  {"proofState": 5,
+   "pos": {"line": 14, "column": 40},
+   "goal": "m n : Nat\nih : n + m = m + n\n⊢ n + m = m + n",
+   "endPos": {"line": 14, "column": 45}},
+  {"proofState": 6,
+   "pos": {"line": 17, "column": 75},
+   "goal":
+   "m n : Nat\nih h_inductive : n + m = m + n\n⊢ m + n.succ = (m + n).succ",
+   "endPos": {"line": 17, "column": 80}},
+  {"proofState": 7,
+   "pos": {"line": 19, "column": 66},
+   "goal":
+   "m n : Nat\nih h_inductive : n + m = m + n\nh_pull_succ_out_from_right : m + n.succ = (m + n).succ\n⊢ (n + m).succ = (m + n).succ",
+   "endPos": {"line": 19, "column": 71}},
+  {"proofState": 8,
+   "pos": {"line": 22, "column": 74},
+   "goal":
+   "m n : Nat\nih h_inductive : n + m = m + n\nh_pull_succ_out_from_right : m + n.succ = (m + n).succ\nh_flip_n_plus_m : (n + m).succ = (m + n).succ\n⊢ n.succ + m = (n + m).succ",
+   "endPos": {"line": 22, "column": 79}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 37},
+   "data": "declaration uses 'sorry'"}],
+ "env": 1}
+

--- a/test/sketch_theorem.in
+++ b/test/sketch_theorem.in
@@ -1,0 +1,34 @@
+{"cmd": "theorem foo : 1 = 1 := by\n
+sorry"}
+
+{"cmd": "theorem add_comm_proved_formal_sketch : ∀ n m : Nat, n + m = m + n := by
+   -- Consider some n and m in Nats.\n
+   intros n m\n
+   -- Perform induction on n.\n
+   induction n with\n
+   | zero =>\n
+     /-
+      Base case: When n = 0, we need to show 0 + m = m + 0.
+      We have the fact 0 + m = m by the definition of addition.
+     -/\n
+     have h_base: 0 + m = m := sorry\n
+     -- We also have the fact m + 0 = m by the definition of addition.\n
+     have h_symm: m + 0 = m := sorry\n
+     -- Combine facts to close goal\n
+     sorry\n
+   | succ n ih =>\n
+     /- Inductive step: Assume n + m = m + n, we need to show succ n + m = m + succ n.
+      By the inductive hypothesis, we have n + m = m + n.
+     -/\n
+     have h_inductive: n + m = m + n := sorry\n
+     -- 1. Note we start with: Nat.succ n + m = m + Nat.succ n, so, pull the succ out from \n
+     -- m + Nat.succ n on the right side from the addition using addition facts Nat.add_succ.\n
+     have h_pull_succ_out_from_right: m + Nat.succ n = Nat.succ (m + n) := sorry\n
+     -- 2. then to flip m + S n to something like S (n + m) we need to use the IH.\n
+     have h_flip_n_plus_m: Nat.succ (n + m) = Nat.succ (m + n) := sorry\n
+     -- 3. Now the n & m are on the correct sides Nat.succ n + m = Nat.succ (n + m),\n
+     -- so let's use the def of addition to pull out the succ from the addition on the left using Nat.succ_add.\n
+     have h_pull_succ_out_from_left: Nat.succ n + m = Nat.succ (n + m) := sorry\n
+     -- Combine facts to close goal\n
+     sorry"}
+


### PR DESCRIPTION
Hi,

I encountered an issue while parsing sketch theorems using REPL. The process was getting stuck for some times. Investigation revealed this is related to the TTY buffer limitation (1024 characters) on MacOS, as discussed [here](https://stackoverflow.com/questions/9218499/pexpect-cant-pass-input-over-1024-chars).

While the current implementation attempts to handle longer inputs by concatenating multiple lines, there's a bug where the newline characters (`\n`) at line endings cause JSON syntax errors.

Current Implementation:
```lean4
partial def getLines : IO String := do
  let line ← (← IO.getStdin).getLine
  if line.trim.isEmpty then
    return line
  else
    return line ++ (← getLines)
```

Proposed Fix:
```lean4
    return line.trimRight ++ (← getLines)
```

This change allows users to break long inputs into multiple lines using line continuation:

<img width="387" alt="image" src="https://github.com/user-attachments/assets/b49dd925-d389-4204-a0ff-f386d38655c7" />

Additionally, while file mode has no input length limitation, the current implementation ignores the `env` field and runs code in a fresh environment. I've updated the `env` field handling as well. Note that all these proposed changes are backward compatible.

Thanks in advance for considering these improvements.