### PR TITLE
Report errors in import statements.

### DIFF
--- a/REPL/Frontend.lean
+++ b/REPL/Frontend.lean
@@ -19,8 +19,9 @@ def processCommandsWithInfoTrees
     (inputCtx : Parser.InputContext) (parserState : Parser.ModuleParserState)
     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
   let commandState := { commandState with infoState.enabled := true }
+  let oldMessages := commandState.messages.toList
   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
-  pure (s, s.messages.toList, s.infoState.trees.toList)
+  pure (s, oldMessages ++ s.messages.toList, s.infoState.trees.toList)
 
 /--
 Process some text input, with or without an existing command state.


### PR DESCRIPTION
Solves the problem that invalid import statements were not reported as errors.

Before:
```
{"cmd": "import BlahBlahBlah"}

{"env": 0}
```

After:
```
{"cmd": "import BlahBlahBlah"}

{"messages":
 [{"severity": "error",
   "pos": {"line": 1, "column": 0},
   "endPos": null,
   "data":
   "unknown module prefix 'BlahBlahBlah'\n\nNo directory 'BlahBlahBlah' or file 'BlahBlahBlah.olean' in the search path entries:\n././.lake/packages/Cli/.lake/build/lib\n././.lake/packages/batteries/.lake/build/lib\n././.lake/packages/Qq/.lake/build/lib\n././.lake/packages/aesop/.lake/build/lib\n././.lake/packages/proofwidgets/.lake/build/lib\n././.lake/packages/importGraph/.lake/build/lib\n././.lake/packages/LeanSearchClient/.lake/build/lib\n././.lake/packages/plausible/.lake/build/lib\n././.lake/packages/mathlib/.lake/build/lib\n././.lake/build/lib\n/home/m/.elan/toolchains/leanprover--lean4---v4.15.0/lib/lean\n/home/m/.elan/toolchains/leanprover--lean4---v4.15.0/lib/lean"}],
 "env": 0}
```

Similarly, invalid import statements were not reported when processing a file using `{"path": "..."}`, which is now fixed.