### PR TITLE
Fix missing local context + valid proofs wrongfully rejected in tactic mode

### DIFF
--- a/REPL/Frontend.lean
+++ b/REPL/Frontend.lean
@@ -28,20 +28,30 @@ If there is no existing environment, we parse the input for headers (e.g. import
 and create a new environment.
 Otherwise, we add to the existing environment.
 
-Returns the resulting command state, along with a list of messages and info trees.
+Returns:
+1. The header-only command state (only useful when cmdState? is none)
+2. The resulting command state after processing the entire input
+3. List of messages
+4. List of info trees
 -/
 def processInput (input : String) (cmdState? : Option Command.State)
     (opts : Options := {}) (fileName : Option String := none) :
-    IO (Command.State × List Message × List InfoTree) := unsafe do
+    IO (Command.State × Command.State × List Message × List InfoTree) := unsafe do
   Lean.initSearchPath (← Lean.findSysroot)
   enableInitializersExecution
   let fileName   := fileName.getD "<input>"
   let inputCtx   := Parser.mkInputContext input fileName
-  let (parserState, commandState) ← match cmdState? with
+
+  match cmdState? with
   | none => do
+    -- Split the processing into two phases to prevent self-reference in proofs in tactic mode
     let (header, parserState, messages) ← Parser.parseHeader inputCtx
     let (env, messages) ← processHeader header opts messages inputCtx
-    pure (parserState, (Command.mkState env messages opts))
-  | some cmdState => do
-    pure ({ : Parser.ModuleParserState }, cmdState)
-  processCommandsWithInfoTrees inputCtx parserState commandState
+    let headerOnlyState := Command.mkState env messages opts
+    let (cmdState, messages, trees) ← processCommandsWithInfoTrees inputCtx parserState headerOnlyState
+    return (headerOnlyState, cmdState, messages, trees)
+
+  | some cmdStateBefore => do
+    let parserState : Parser.ModuleParserState := {}
+    let (cmdStateAfter, messages, trees) ← processCommandsWithInfoTrees inputCtx parserState cmdStateBefore
+    return (cmdStateBefore, cmdStateAfter, messages, trees)

--- a/test/assumption_proof.expected.out
+++ b/test/assumption_proof.expected.out
@@ -1,0 +1,14 @@
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 1, "column": 49},
+   "goal": "x : Nat\nh1 : x = 2\n⊢ x = 2",
+   "endPos": {"line": 1, "column": 54}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 10},
+   "data": "declaration uses 'sorry'"}],
+ "env": 0}
+
+{"proofStatus": "Completed", "proofState": 1, "goals": []}
+

--- a/test/assumption_proof.in
+++ b/test/assumption_proof.in
@@ -1,0 +1,3 @@
+{"cmd": "theorem aa (x : Nat) (h1 : x  = 2) : x = 2 := by sorry"}
+
+{"tactic": "assumption", "proofState": 0}

--- a/test/name_generator.expected.out
+++ b/test/name_generator.expected.out
@@ -43,7 +43,7 @@
  "proofState": 7,
  "goals": []}
 
-{"proofStatus": "Incomplete: contains sorry",
+{"proofStatus": "Incomplete: contains metavariable(s)",
  "proofState": 8,
  "messages":
  [{"severity": "error",
@@ -52,7 +52,7 @@
    "data": "unsolved goals\nx : Int\nh0 : x > 0\n⊢ x > 0"}],
  "goals": []}
 
-{"proofStatus": "Incomplete: contains sorry",
+{"proofStatus": "Incomplete: contains metavariable(s)",
  "proofState": 9,
  "messages":
  [{"severity": "error",

--- a/test/proof_branching.expected.out
+++ b/test/proof_branching.expected.out
@@ -1,0 +1,28 @@
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 1, "column": 75},
+   "goal": "p q r : Prop\nh1 : p ∧ q\nh2 : q → r\n⊢ p ∧ r",
+   "endPos": {"line": 1, "column": 80}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 19},
+   "data": "declaration uses 'sorry'"}],
+ "env": 0}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 1,
+ "goals":
+ ["case left\np q r : Prop\nh1 : p ∧ q\nh2 : q → r\n⊢ p",
+  "case right\np q r : Prop\nh1 : p ∧ q\nh2 : q → r\n⊢ r"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 2,
+ "goals": ["case right\np q r : Prop\nh1 : p ∧ q\nh2 : q → r\n⊢ r"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 3,
+ "goals": ["case right\np q r : Prop\nh1 : p ∧ q\nh2 : q → r\n⊢ q"]}
+
+{"proofStatus": "Completed", "proofState": 4, "goals": []}
+

--- a/test/proof_branching.in
+++ b/test/proof_branching.in
@@ -1,0 +1,10 @@
+{"cmd": "theorem complex_and (p q r : Prop) (h1 : p ∧ q) (h2 : q → r) : p ∧ r := by sorry"}
+
+{"tactic": "apply And.intro", "proofState": 0}
+
+{"tactic": "exact h1.left", "proofState": 1}
+
+{"tactic": "apply h2", "proofState": 2}
+
+{"tactic": "exact h1.right", "proofState": 3}
+

--- a/test/proof_branching2.expected.out
+++ b/test/proof_branching2.expected.out
@@ -1,0 +1,36 @@
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 1, "column": 43},
+   "goal": "p q : Prop\n⊢ p ∧ q → q ∧ p",
+   "endPos": {"line": 1, "column": 48}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 0},
+   "endPos": {"line": 1, "column": 7},
+   "data": "declaration uses 'sorry'"}],
+ "env": 0}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 1,
+ "goals": ["p q : Prop\nh : p ∧ q\n⊢ q ∧ p"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 2,
+ "goals": ["p q : Prop\nh : p ∧ q\nhp : p\n⊢ q ∧ p"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 3,
+ "goals": ["p q : Prop\nh : p ∧ q\nhp : p\nhq : q\n⊢ q ∧ p"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 4,
+ "goals":
+ ["case left\np q : Prop\nh : p ∧ q\nhp : p\nhq : q\n⊢ q",
+  "case right\np q : Prop\nh : p ∧ q\nhp : p\nhq : q\n⊢ p"]}
+
+{"proofStatus": "Incomplete: open goals remain",
+ "proofState": 5,
+ "goals": ["case right\np q : Prop\nh : p ∧ q\nhp : p\nhq : q\n⊢ p"]}
+
+{"proofStatus": "Completed", "proofState": 6, "goals": []}
+

--- a/test/proof_branching2.in
+++ b/test/proof_branching2.in
@@ -1,0 +1,14 @@
+{"cmd": "example (p q : Prop) : p ∧ q → q ∧ p := by sorry"}
+
+{"tactic": "intro h", "proofState": 0}
+
+{"tactic": "have hp : p := h.left", "proofState": 1}
+
+{"tactic": "have hq : q := h.right", "proofState": 2}
+
+{"tactic": "apply And.intro", "proofState": 3}
+
+{"tactic": "exact hq", "proofState": 4}
+
+{"tactic": "exact hp", "proofState": 5}
+

--- a/test/proof_transitivity.expected.out
+++ b/test/proof_transitivity.expected.out
@@ -1,0 +1,28 @@
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 1, "column": 62},
+   "goal": "x y z : Nat\nh1 : x = y\nh2 : y = z\n⊢ x = z",
+   "endPos": {"line": 1, "column": 67}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 0},
+   "endPos": {"line": 1, "column": 7},
+   "data": "declaration uses 'sorry'"}],
+ "env": 0}
+
+{"proofStatus": "Completed", "proofState": 1, "goals": []}
+
+{"sorries":
+ [{"proofState": 2,
+   "pos": {"line": 1, "column": 64},
+   "goal": "f : Nat → Nat\nn : Nat\nh : n = 3\n⊢ f n = f 3",
+   "endPos": {"line": 1, "column": 69}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 0},
+   "endPos": {"line": 1, "column": 7},
+   "data": "declaration uses 'sorry'"}],
+ "env": 1}
+
+{"proofStatus": "Completed", "proofState": 3, "goals": []}
+

--- a/test/proof_transitivity.in
+++ b/test/proof_transitivity.in
@@ -1,0 +1,8 @@
+{"cmd": "example (x y z : Nat) (h1 : x = y) (h2 : y = z) : x = z := by sorry"}
+
+{"tactic": "exact Eq.trans h1 h2", "proofState": 0}
+
+{"cmd": "example (f : Nat → Nat) (n : Nat) (h : n = 3) : f n = f 3 := by sorry"}
+
+{"tactic": "exact congrArg f h", "proofState": 2}
+

--- a/test/self_proof_check.expected.out
+++ b/test/self_proof_check.expected.out
@@ -1,0 +1,23 @@
+{"messages":
+ [{"severity": "error",
+   "pos": {"line": 1, "column": 25},
+   "endPos": {"line": 1, "column": 31},
+   "data":
+   "`exact?` could not close the goal. Try `apply?` to see partial suggestions."}],
+ "env": 0}
+
+{"sorries":
+ [{"proofState": 0,
+   "pos": {"line": 1, "column": 22},
+   "goal": "⊢ False",
+   "endPos": {"line": 1, "column": 27}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 10},
+   "data": "declaration uses 'sorry'"}],
+ "env": 1}
+
+{"message":
+ "Lean error:\n`exact?` could not close the goal. Try `apply?` to see partial suggestions."}
+

--- a/test/self_proof_check.expected.out
+++ b/test/self_proof_check.expected.out
@@ -21,3 +21,69 @@
 {"message":
  "Lean error:\n`exact?` could not close the goal. Try `apply?` to see partial suggestions."}
 
+{"sorries":
+ [{"proofState": 1,
+   "pos": {"line": 1, "column": 25},
+   "goal": "⊢ False",
+   "endPos": {"line": 1, "column": 30}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 10},
+   "data": "declaration uses 'sorry'"}],
+ "env": 2}
+
+{"message":
+ "Lean error:\n`exact?` could not close the goal. Try `apply?` to see partial suggestions."}
+
+{"tactics":
+ [{"usedConstants":
+   ["False",
+    "sorryAx",
+    "instOfNatNat",
+    "Lean.Name.num",
+    "Lean.Name.str",
+    "Lean.Name.anonymous",
+    "Nat",
+    "Lean.Name",
+    "OfNat.ofNat",
+    "Bool.false"],
+   "tactic": "sorry",
+   "proofState": 3,
+   "pos": {"line": 1, "column": 25},
+   "goals": "⊢ False",
+   "endPos": {"line": 1, "column": 30}}],
+ "sorries":
+ [{"proofState": 2,
+   "pos": {"line": 1, "column": 25},
+   "goal": "⊢ False",
+   "endPos": {"line": 1, "column": 30}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 10},
+   "data": "declaration uses 'sorry'"}],
+ "env": 3}
+
+{"message":
+ "Lean error:\n`exact?` could not close the goal. Try `apply?` to see partial suggestions."}
+
+{"sorries":
+ [{"proofState": 4,
+   "pos": {"line": 1, "column": 25},
+   "goal": "⊢ False",
+   "endPos": {"line": 1, "column": 30}},
+  {"proofState": 5,
+   "pos": {"line": 1, "column": 22},
+   "goal": "⊢ False",
+   "endPos": {"line": 1, "column": 22}}],
+ "messages":
+ [{"severity": "warning",
+   "pos": {"line": 1, "column": 8},
+   "endPos": {"line": 1, "column": 10},
+   "data": "declaration uses 'sorry'"}],
+ "env": 4}
+
+{"message":
+ "Lean error:\n`exact?` could not close the goal. Try `apply?` to see partial suggestions."}
+

--- a/test/self_proof_check.in
+++ b/test/self_proof_check.in
@@ -4,3 +4,15 @@
 
 {"proofState": 0, "tactic": "exact?"}
 
+{"cmd": "theorem ex : False := by sorry"}
+
+{"proofState": 1, "tactic": "exact?"}
+
+{"cmd": "theorem ex : False := by sorry", "allTactics": true}
+
+{"proofState": 3, "tactic": "exact?"}
+
+{"cmd": "theorem ex : False := by sorry", "rootGoals": true}
+
+{"proofState": 5, "tactic": "exact?"}
+

--- a/test/self_proof_check.in
+++ b/test/self_proof_check.in
@@ -1,0 +1,6 @@
+{"cmd": "theorem ex : False := by exact?"}
+
+{"cmd": "theorem ex : False := sorry"}
+
+{"proofState": 0, "tactic": "exact?"}
+


### PR DESCRIPTION
Previous PR #63 only checked if invalid proofs were caught.
It turns out that it rejects a large class of valid proofs: those relying on local hypotheses.

This PR fixes this by:
- Adding the missing local context when collecting tactic sorries
- Handling FVars correctly before doing the kernel check
- Adding new tests with slightly more complex valid proofs than existing ones

Note: the `getProofStatus` method is now also closer to LeanDojo [`validateProof`](https://github.com/lean-dojo/LeanDojo/blob/5f980887df0c78925527b9411179ae146dad357f/src/lean_dojo/interaction/Lean4Repl.lean#L170-L215) method