### PR TITLE
Add syntax node kinds to syntax json

### DIFF
--- a/REPL/Lean/InfoTree/ToJson.lean
+++ b/REPL/Lean/InfoTree/ToJson.lean
@@ -26,7 +26,14 @@ structure Syntax.Json where
   pp : Option String
   -- raw : String
   range : Range
+  kind: String
+  argKinds: Array String
 deriving ToJson
+
+
+def _root_.Lean.Syntax.argKinds (stx : Syntax) : Array String :=
+  stx.getArgs.map fun s => s.getKind.toString
+
 
 def _root_.Lean.Syntax.toRange (stx : Syntax) (ctx : ContextInfo) : Syntax.Range :=
   let pos    := stx.getPos?.getD 0
@@ -43,6 +50,8 @@ def _root_.Lean.Syntax.toJson (stx : Syntax) (ctx : ContextInfo) (lctx : LocalCo
       | "failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)" => none
       | pp => some pp
     -- raw := toString stx
+    kind := stx.getKind.toString
+    argKinds := stx.argKinds
     range := stx.toRange ctx }
 
 structure TacticInfo.Json where
@@ -59,6 +68,8 @@ def TacticInfo.toJson (i : TacticInfo) (ctx : ContextInfo) : IO TacticInfo.Json 
     stx :=
     { pp := Format.pretty (← i.pp ctx),
       -- raw := toString i.info.stx,
+      kind := i.stx.getKind.toString,
+      argKinds := i.stx.argKinds,
       range := i.stx.toRange ctx },
     goalsBefore := (← i.goalState ctx).map Format.pretty,
     goalsAfter := (← i.goalStateAfter ctx).map Format.pretty }


### PR DESCRIPTION
Currently, the Syntax part of the InfoTree json is missing a lot of information compared to the Syntax object in Lean. The changes here enable to check for specific SyntaxNodeKinds in the InfoTree. Also, I included the kinds of the node array, as these are not the same as the SyntaxNodeKind of child InfoTrees.
The `argKinds` are for example needed to differentiate between theorem and def for a CommandInfo with a Syntax of SyntaxNodeKind `Lean.Parser.Command.declaration`.

For example, getting all theorems of an InfoTree (in Python using dataclasses for illustration) involves:
```python3
    def theorems(self) -> Generator[Self, None, None]:
        for tree in self.commands():
            if tree.node.stx.kind != "Lean.Parser.Command.declaration":
               continue
            if tree.node.stx.argKinds[-1] != "Lean.Parser.Command.theorem":
                continue
            yield tree
```