### PR TITLE
Add Pantograph-like approach to tactic mode

### DIFF
--- a/REPL/JSON.lean
+++ b/REPL/JSON.lean
@@ -149,7 +149,6 @@ structure ProofStepResponse where
   proofState : Nat
   goals : List String
   messages : List Message := []
-  sorries : List Sorry := []
   traces : List String
   proofStatus : String
 deriving ToJson, FromJson
@@ -159,7 +158,6 @@ instance : ToJson ProofStepResponse where
     [("proofState", r.proofState)],
     [("goals", toJson r.goals)],
     Json.nonemptyList "messages" r.messages,
-    Json.nonemptyList "sorries" r.sorries,
     Json.nonemptyList "traces" r.traces,
     [("proofStatus", r.proofStatus)]
   ]

--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -235,22 +235,11 @@ def createProofStepReponse (proofState : ProofSnapshot) (old? : Option ProofSnap
   let messages := proofState.newMessages old?
   let messages ← messages.mapM fun m => Message.of m
   let traces ← proofState.newTraces old?
-  let trees := proofState.newInfoTrees old?
-  let trees ← match old? with
-  | some old => do
-    let (ctx, _) ← old.runMetaM do return { ← CommandContextInfo.save with }
-    let ctx := PartialContextInfo.commandCtx ctx
-    pure <| trees.map fun t => InfoTree.context ctx t
-  | none => pure trees
-  -- For debugging purposes, sometimes we print out the trees here:
-  -- trees.forM fun t => do IO.println (← t.format)
-  let sorries ← sorries trees none (some proofState.rootGoals)
   let id ← recordProofSnapshot proofState
   return {
     proofState := id
-    goals := (← proofState.ppGoals).map fun s => s!"{s}"
+    goals := (← proofState.ppGoals).map (s!"{·}")
     messages
-    sorries
     traces
     proofStatus := (← getProofStatus proofState) }
 
@@ -349,8 +338,10 @@ def processFile (s : File) : M IO (CommandResponse ⊕ Error) := do
 
 /--
 Run a single tactic, returning the id of the new proof statement, and the new goals.
+This implementation supports branching in tactic proofs.
+When a tactic generates new goals, each goal is properly tracked to allow subsequent tactics to be
+applied.
 -/
--- TODO detect sorries?
 def runProofStep (s : ProofStep) : M IO (ProofStepResponse ⊕ Error) := do
   match (← get).proofStates[s.proofState]? with
   | none => return .inr ⟨"Unknown proof state."⟩

--- a/REPL/Snapshots.lean
+++ b/REPL/Snapshots.lean
@@ -114,6 +114,20 @@ namespace ProofSnapshot
 
 open Lean Elab Tactic
 
+/-- Transform `sorry` expressions into fresh opaque metavariables, collecting their IDs. -/
+def sorryToHole (src : Expr) : StateRefT (List MVarId) MetaM Expr :=
+  Meta.transform src λ expr =>
+    if expr.isSorry then do
+      -- extract the proof type from `sorry` (the first binder argument)
+      let type ← instantiateMVars (expr.getArg! 0 |>.bindingBody!)
+      if type.hasSorry then
+        throwError s!"Nested sorry in type not supported: {← Meta.ppExpr type}"
+      let mvar ← Meta.mkFreshExprSyntheticOpaqueMVar type
+      modify (mvar.mvarId! :: ·)
+      pure $ .done mvar
+    else
+      pure .continue
+
 /-- New messages in a `ProofSnapshot`, relative to an optional previous `ProofSnapshot`. -/
 def newMessages (new : ProofSnapshot) (old? : Option ProofSnapshot := none) : List Lean.Message :=
   match old? with
@@ -180,7 +194,26 @@ and run it in the current `ProofSnapshot`.
 def runString (p : ProofSnapshot) (t : String) : IO ProofSnapshot :=
   match Parser.runParserCategory p.coreState.env `tactic t with
   | .error e => throw (IO.userError e)
-  | .ok stx => p.runSyntax stx
+  | .ok stx => do
+    let result ← p.runSyntax stx
+
+    -- Process all goals after tactic execution to find and transform any sorries
+    let (newGoals, result') ← result.runMetaM do
+      let processExpr (acc : List MVarId) (mvarId : MVarId) (expr : Expr) : MetaM (List MVarId) := do
+        if expr.hasSorry then
+          let (newExpr, exprHoles) ← sorryToHole expr |>.run []
+          mvarId.assign newExpr
+          pure (acc ++ exprHoles)
+        else
+          pure acc
+
+      -- Process all expressions in the metavariable context
+      let mctx := result.metaState.mctx
+      let exprHoles ← mctx.eAssignment.foldlM processExpr []
+      pure exprHoles
+
+    let combinedGoals := result'.tacticState.goals ++ newGoals
+    return { result' with tacticState := { goals := combinedGoals } }
 
 /-- Pretty print the current goals in the `ProofSnapshot`. -/
 def ppGoals (p : ProofSnapshot) : IO (List Format) :=


### PR DESCRIPTION
This PR implements an approach similar to [Pantograph](https://arxiv.org/abs/2410.16429): it transforms sorries introduced in tactic mode as new goals in the **same** proof state. This removes the branching problem, making possible to run kernel check of such proofs.

TODO:

- [ ] Adding tests
- [ ] Update the `sorries` method to instantiate a unique proofstate per declaration
- [ ] Adding an attribute to focus on goals / group of goals

### Example
Input:
```
{"cmd": "example : 1 = 1 := by sorry"}

{"tactic": "have h : 2 = 2 := by sorry", "proofState": 0}

{"tactic": "rfl", "proofState": 1}

{"tactic": "rfl", "proofState": 2}
```

Previous output:
```
{"sorries":
 [{"proofState": 0,
   "pos": {"line": 1, "column": 22},
   "goal": "⊢ 1 = 1",
   "endPos": {"line": 1, "column": 27}}],
 "messages":
 [{"severity": "warning",
   "pos": {"line": 1, "column": 0},
   "endPos": {"line": 1, "column": 7},
   "data": "declaration uses 'sorry'"}],
 "env": 0}

{"sorries": [{"proofState": 1, "goal": "⊢ 2 = 2"}],
 "proofStatus": "Incomplete: open goals remain",
 "proofState": 2,
 "goals": ["this : 2 = 2\n⊢ 1 = 1"]}

{"proofStatus": "Incomplete: contains metavariable(s)",
 "proofState": 3,
 "goals": []}

{"proofStatus": "Incomplete: contains sorry", "proofState": 4, "goals": []}
```

New output:
```
{"sorries":
 [{"proofState": 0,
   "pos": {"line": 1, "column": 22},
   "goal": "⊢ 1 = 1",
   "endPos": {"line": 1, "column": 27}}],
 "messages":
 [{"severity": "warning",
   "pos": {"line": 1, "column": 0},
   "endPos": {"line": 1, "column": 7},
   "data": "declaration uses 'sorry'"}],
 "env": 0}

{"proofStatus": "Incomplete: open goals remain",
 "proofState": 1,
 "goals": ["this : 2 = 2\n⊢ 1 = 1", "⊢ 2 = 2"]}

{"proofStatus": "Incomplete: open goals remain",
 "proofState": 2,
 "goals": ["⊢ 2 = 2"]}

{"proofStatus": "Completed", "proofState": 3, "goals": []}
```