### PR TITLE
Theorem type

### DIFF
--- a/REPL/JSON.lean
+++ b/REPL/JSON.lean
@@ -188,4 +188,13 @@ structure UnpickleProofState where
   env : Option Nat
 deriving ToJson, FromJson
 
+structure GetDeclType where
+  env: Option Nat
+  decl: String
+deriving ToJson, FromJson
+
+structure DeclTypeResponse where
+  types: List String
+deriving ToJson, FromJson
+
 end REPL

--- a/REPL/Lean/InfoTree.lean
+++ b/REPL/Lean/InfoTree.lean
@@ -190,6 +190,20 @@ def findTacticNodes (t : InfoTree) : List (TacticInfo × ContextInfo × List MVa
   | (.ofTacticInfo i, some ctx, rootGoals) => (i, ctx, rootGoals)
   | _ => none
 
+/-- Returns all `TermInfo` nodes for a given `InfoTree`. -/
+partial def findTermNodes (t : InfoTree) (ctx? : Option ContextInfo := none) :
+  List (TermInfo × ContextInfo) :=
+  match t with
+  | .context ctx t => t.findTermNodes (ctx.mergeIntoOuter? ctx?)
+  | .node info ts =>
+    match info with
+    | .ofTermInfo i =>
+      match ctx? with
+      | some ctx => [(i, ctx)]
+      | _ => []
+    | _ => ts.toList.flatMap (fun t => t.findTermNodes ctx?)
+  | _ => []
+
 /-- Returns the root goals for a given `InfoTree`. -/
 partial def findRootGoals (t : InfoTree) (ctx? : Option ContextInfo := none) :
   List (TacticInfo × ContextInfo × List MVarId) :=

--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -289,6 +289,35 @@ def unpickleProofSnapshot (n : UnpickleProofState) : M IO (ProofStepResponse ⊕
   let (proofState, _) ← ProofSnapshot.unpickle n.unpickleProofStateFrom cmdSnapshot?
   Sum.inl <$> createProofStepReponse proofState
 
+def getDeclType (n: GetDeclType) : M IO (DeclTypeResponse ⊕ Error) := do
+  let (cmdSnapshot?, notFound) ← do match n.env with
+  | none => pure (none, false)
+  | some i => do match (← get).cmdStates[i]? with
+    | some env => pure (some env, false)
+    | none => pure (none, true)
+  if notFound then
+    return .inr ⟨"Unknown environment."⟩
+  let initialCmdState? := cmdSnapshot?.map fun c => c.cmdState
+  let (initialCmdState, cmdState, messages, trees) ← try
+    IO.processInput n.decl initialCmdState?
+  catch ex =>
+    return .inr ⟨ex.toString⟩
+  trees.forM fun t => do IO.println (← t.format)
+  IO.println (trees.map (fun t => (t.findRootGoals.length)))
+
+  let optional_decls: List String ← trees.flatMap InfoTree.findRootGoals |>.mapM
+    fun ⟨t, ctx, goals⟩ => do
+      let mctx := ctx.mctx
+      let x := fun (m: MVarId) => do
+        let localContext : LocalContext := (← m.getDecl).lctx
+        match localContext.decls.get! 0 with
+        | none             => pure ""
+        | some firstDecl   => pure ((← Meta.ppExpr (← Lean.Meta.inferType firstDecl.toExpr)).pretty')
+      t.runMetaM ctx x
+  IO.println optional_decls
+  let decls := optional_decls.filter (fun s => !s.isEmpty)
+  return .inl (DeclTypeResponse.mk decls)
+
 /--
 Run a command, returning the id of the new environment, and any messages and sorries.
 -/
@@ -387,6 +416,7 @@ inductive Input
 | unpickleEnvironment : REPL.UnpickleEnvironment → Input
 | pickleProofSnapshot : REPL.PickleProofState → Input
 | unpickleProofSnapshot : REPL.UnpickleProofState → Input
+| getDeclType : REPL.GetDeclType → Input
 
 /-- Parse a user input string to an input command. -/
 def parse (query : String) : IO Input := do
@@ -408,6 +438,8 @@ def parse (query : String) : IO Input := do
     | .ok (r : REPL.Command) => return .command r
     | .error _ => match fromJson? j with
     | .ok (r : REPL.File) => return .file r
+    | .error _ => match fromJson? j with
+    | .ok (r: REPL.GetDeclType) => return .getDeclType r
     | .error e => throw <| IO.userError <| toString <| toJson <|
         (⟨"Could not parse as a valid JSON command:\n" ++ e⟩ : Error)
 
@@ -433,6 +465,7 @@ where loop : M IO Unit := do
   | .unpickleEnvironment r => return toJson (← unpickleCommandSnapshot r)
   | .pickleProofSnapshot r => return toJson (← pickleProofSnapshot r)
   | .unpickleProofSnapshot r => return toJson (← unpickleProofSnapshot r)
+  | .getDeclType r => return toJson (← getDeclType r)
   printFlush "\n" -- easier to parse the output if there are blank lines
   loop
 

--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -298,25 +298,19 @@ def getDeclType (n: GetDeclType) : M IO (DeclTypeResponse ⊕ Error) := do
   if notFound then
     return .inr ⟨"Unknown environment."⟩
   let initialCmdState? := cmdSnapshot?.map fun c => c.cmdState
-  let (initialCmdState, cmdState, messages, trees) ← try
+  let (_, _, _, trees) ← try
     IO.processInput n.decl initialCmdState?
   catch ex =>
     return .inr ⟨ex.toString⟩
-  trees.forM fun t => do IO.println (← t.format)
-  IO.println (trees.map (fun t => (t.findRootGoals.length)))
-
-  let optional_decls: List String ← trees.flatMap InfoTree.findRootGoals |>.mapM
-    fun ⟨t, ctx, goals⟩ => do
-      let mctx := ctx.mctx
-      let x := fun (m: MVarId) => do
-        let localContext : LocalContext := (← m.getDecl).lctx
-        match localContext.decls.get! 0 with
-        | none             => pure ""
-        | some firstDecl   => pure ((← Meta.ppExpr (← Lean.Meta.inferType firstDecl.toExpr)).pretty')
-      t.runMetaM ctx x
-  IO.println optional_decls
+  let terms := trees.map InfoTree.findTermNodes
+  let innermost := (fun (t : TermInfo) => do pure (← Meta.ppExpr (← Lean.Meta.inferType t.expr)).pretty')
+  let inner := (fun t : (TermInfo × ContextInfo) => t.snd.runMetaM t.fst.lctx (innermost t.fst))
+  let optional_decls: List String ← terms.mapM fun treeterms => do
+    match treeterms.getLast? with
+    | none => pure ""
+    | some a => inner a
   let decls := optional_decls.filter (fun s => !s.isEmpty)
-  return .inl (DeclTypeResponse.mk decls)
+  return .inl <| DeclTypeResponse.mk decls
 
 /--
 Run a command, returning the id of the new environment, and any messages and sorries.

--- a/test/gettype.expected.out
+++ b/test/gettype.expected.out
@@ -1,0 +1,6 @@
+{"types": ["∀ (p : Prop), p → p"]}
+
+{"types": ["∀ (p : Prop), p → p"]}
+
+{"types": ["∀ (p : Prop), p → p", "∀ (q : Prop), q → q"]}
+

--- a/test/gettype.in
+++ b/test/gettype.in
@@ -1,0 +1,5 @@
+{"decl": "theorem show_p (p : Prop) (h : p) : p := by exact h"}
+
+{"decl": "def show_q (p : Prop) (h : p) : p := h"}
+
+{"decl": "def show_q (p : Prop) (h : p) : p := h\n\ndef show_p (q : Prop) (h : q) : q := h"}


### PR DESCRIPTION
Added a new command that retrieves the corresponding type for a definition.

Given that the approach of separate lemmas is becoming more popular, this might be interesting to have.
Consider the following:
```
lemma A := by <proof-of-a>

lemma B := by <proof-of-b>

theorem C := by
  have A := by <proof-of-a>

  have B := by <proof-of-b>

  <regular-proof>
```

which is the current approach, for example used in DeepSeekProver v2.
This is inherently redundant. Importantly, the proof of A, B is not even necessary in C.

Instead, one can now write
```
theorem C (hx: type of A) (hy: type of B) := by <regular-proof>
```

and compose via
```
exact C A B
```