### PR TITLE
fix: set local context in getProofStatus (triggered when continuing proof from allTactics and rootGoals)

### DIFF
--- a/REPL/Main.lean
+++ b/REPL/Main.lean
@@ -185,6 +185,7 @@ def getProofStatus (proofState : ProofSnapshot) : M m String := do
       let res := proofState.runMetaM do
         match proofState.rootGoals with
         | [goalId] =>
+          goalId.withContext do
           match proofState.metaState.mctx.getExprAssignmentCore? goalId with
           | none => return "Error: Goal not assigned"
           | some pf => do
@@ -196,7 +197,7 @@ def getProofStatus (proofState : ProofSnapshot) : M m String := do
             unless (← Meta.isDefEq pft expectedType) do
               return s!"Error: proof has type {pft} but root goal has type {expectedType}"
 
-            let pf ← goalId.withContext $ abstractAllLambdaFVars pf
+            let pf ← abstractAllLambdaFVars pf
             let pft ← Meta.inferType pf >>= instantiateMVars
 
             if pf.hasExprMVar then

--- a/test/all_tactics-20250622.expected.out
+++ b/test/all_tactics-20250622.expected.out
@@ -1,0 +1,11 @@
+{"tactics":
+ [{"usedConstants": [],
+   "tactic": "exact hp",
+   "proofState": 0,
+   "pos": {"line": 2, "column": 2},
+   "goals": "P : Prop\nhp : P\n⊢ P",
+   "endPos": {"line": 2, "column": 10}}],
+ "env": 0}
+
+{"proofStatus": "Completed", "proofState": 1, "goals": []}
+

--- a/test/all_tactics-20250622.in
+++ b/test/all_tactics-20250622.in
@@ -1,0 +1,4 @@
+{"cmd": "example (P : Prop) (hp : P) : P := by\n  exact hp\n", "allTactics": true}
+
+{"tactic": "exact hp", "proofState": 0}
+


### PR DESCRIPTION
This PR fixes an error where the local context of a root goal is different from the `lctx` in `Meta.Context` in a `ProofSnapshot`. This is triggered by continuing proofs from proof states created through `rootGoals` and `allTactics` (where `lctx? := none` in `ProofSnapshot.create`).

Input:
```
{"cmd": "example (P : Prop) (hp : P) : P := by\n  exact hp\n", "allTactics": true}

{"tactic": "exact hp", "proofState": 0}
```

Previously the output was:
```
{"message": "Lean error:\nunknown free variable '_fvar.10'"}
```

Now the output is:
```
{"proofStatus": "Completed", "proofState": 1, "goals": []}
```